### PR TITLE
added fix for plan update with incorrect format, and reparsing when 0…

### DIFF
--- a/utils/migration.py
+++ b/utils/migration.py
@@ -131,7 +131,10 @@ def migrate_plan_to_v2(plan_markdown: str, plan_data: Optional[Dict[str, Any]],
         # Current AI format: **Type: Description** [PRIORITY] (single line)
         # Bullet point is optional (AI sometimes forgets it)
         # Matches both: *   **Run: ...** [KEY] and **Run: ...** [KEY]
-        session_pattern_current = r'^(?:\*\s+)?\*\*([A-Za-z&\s]+):\s+([^\*]+)\*\*\s+\[([^\]]+)\]'
+        # Also handles day prefixes like: **Tue Jan 20:** **Run: ...** [KEY] or **Mon:** **Run: ...** [KEY]
+        # Pattern allows optional day prefix (e.g., **Mon:** or **Tue Jan 20:**) before the session pattern
+        # The pattern doesn't require line start, allowing it to match anywhere in the line
+        session_pattern_current = r'(?:\*\s+)?(?:\*\*[^:]+:\*\*\s+)?\*\*([A-Za-z&\s]+):\s+([^\*]+)\*\*\s+\[([^\]]+)\]'
         matches_current = list(re.finditer(session_pattern_current, week_text, re.MULTILINE))
         
         # Legacy formats (for backward compatibility with existing DB plans)


### PR DESCRIPTION
… session weeks are detected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves robustness of plan parsing and recovery when sessions aren’t extracted.
> 
> - **Auto-reparse on dashboard:** Detects `plan_v2` weeks with 0 sessions, reparses from `plan` markdown via `migrate_plan_to_v2`, preserves completed session metadata, and saves updated `plan_v2`.
> - **New endpoint:** Adds `POST /reparse_plan` to manually trigger reparsing with preservation and returns JSON stats (`weeks`, `weeks_with_sessions`, `total_sessions`, `restored_completed`).
> - **Parser fix:** Broadens `session_pattern_current` in `utils/migration.py` to handle optional day prefixes (e.g., `**Mon:**`) and non-line-start matches, reducing missed sessions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01d71da8b0e652bf4b385e037ad810210daccc68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->