### PR TITLE
chore: ignore local previous chat transcripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,6 +201,7 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+.cursor/context/previous-chats/
 
 # Marimo
 marimo/_static/


### PR DESCRIPTION
Changed: Updated .gitignore to exclude .cursor/context/previous-chats/ so exported Cursor chat transcripts remain local-only and are not tracked in version control.
Reasoning: Protects potentially sensitive conversational context while still allowing the editor to use those transcripts locally when referenced.